### PR TITLE
Set up Docker Compose to test `gram` locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# We use builder pattern to optimize the image size.
+FROM golang:1.22-alpine AS build
+
+WORKDIR /gram
+
+ENV BUILD_PACKAGES make
+RUN apk add --no-cache $BUILD_PACKAGES
+
+# Optimize to use cached image if go.mod and go.sum didn't change.
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN make gram
+
+# A runtime image has only binary and config file from a build image.
+FROM alpine:latest
+
+WORKDIR /root
+EXPOSE 1319
+
+COPY --from=build /gram/bin/gram /usr/bin/gram
+COPY --from=build /gram/config.json /root/config.json
+
+ENTRYPOINT ["gram"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+version: "3"
+
+services:
+  gram0:
+    container_name: gram0
+    build: .
+    ports:
+      - "1317:1319"
+    networks:
+      localnet:
+        ipv4_address: 192.168.10.2
+
+  gram1:
+    container_name: gram1
+    build: .
+    ports:
+      - "1318:1319"
+    networks:
+      localnet:
+        ipv4_address: 192.168.10.3
+
+  gram2:
+    container_name: gram2
+    build: .
+    ports:
+      - "1319:1319"
+    networks:
+      localnet:
+        ipv4_address: 192.168.10.4
+
+networks:
+  localnet:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 192.168.10.0/24

--- a/network/rpc.go
+++ b/network/rpc.go
@@ -3,6 +3,7 @@ package network
 import (
 	"bufio"
 	"context"
+	"io"
 	"os"
 )
 
@@ -29,6 +30,9 @@ func (rpc *RPC) rpcMessageHandler() {
 
 	for {
 		message, err := reader.ReadString('\n')
+		if err == io.EOF {
+			continue
+		}
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
#### Changes
- Add Dockerfile.
- Add Docker Compose file.

Type `docker-compose up` to run test locally. We're using CLI chat at the moment so all we can see is three containers get connected to each other. The CLI chat will be replaced with RPC soon and when it's done, we should test RPC, too.